### PR TITLE
Add missing dependency so the example can build by itself

### DIFF
--- a/examples/react-typescript/package.json
+++ b/examples/react-typescript/package.json
@@ -27,6 +27,7 @@
     "electron": "~11.2.1",
     "electron-builder": "~22.9.1",
     "electron-esbuild": "~1.0.0",
+    "electron-util": "~0.14.2",
     "fork-ts-checker-webpack-plugin": "~6.1.0",
     "html-webpack-plugin": "~4.5.1",
     "mini-css-extract-plugin": "~1.3.5",


### PR DESCRIPTION
I ran into this minor issue when trying to run the example the first time.

1. Clone the repo
2. Only install packages in example/react-typescript
3. Build fails because `electron-utils` is missing (only works if the root is installed since module resolution is recursive)