### PR TITLE
feat(electron-esbuild): remove COEP headers in document load

### DIFF
--- a/packages/electron-esbuild/src/builder/esbuild.ts
+++ b/packages/electron-esbuild/src/builder/esbuild.ts
@@ -135,10 +135,11 @@ export class EsbuildBuilder extends BaseBuilder<BuildOptions> {
 
           handler.use(compression() as never)
           handler.use((req, res) => {
+            res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+            res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+
             if (req.url === '/' || req.url === '') {
               res.setHeader('Content-Type', 'text/html')
-              res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
-              res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
               res.writeHead(200)
               res.end(html)
             } else if (req.url?.includes('livereload.js')) {

--- a/packages/electron-esbuild/src/builder/esbuild.ts
+++ b/packages/electron-esbuild/src/builder/esbuild.ts
@@ -135,9 +135,6 @@ export class EsbuildBuilder extends BaseBuilder<BuildOptions> {
 
           handler.use(compression() as never)
           handler.use((req, res) => {
-            res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
-            res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
-
             if (req.url === '/' || req.url === '') {
               res.setHeader('Content-Type', 'text/html')
               res.writeHead(200)


### PR DESCRIPTION
Fixes #12 

**Scenario**:
1. HTML file, when retrieved, will fall through `if (req.url === '/' || req.url === '')` block resulting in the CORS header being set for the whole document
![image](https://user-images.githubusercontent.com/13672022/119475758-a14f0380-bd77-11eb-8b3c-fbd68fb47cde.png)

2. Let's say we want to add new worker file, which we need to add a new `entryPoints` in `esbuild.renderer.config.js` in order to bundle the worker file. Example: https://github.com/josteph/josteph-electron-esbuild/blob/912a2e9243c938d261fe91713b48debfe9ece4c3/config/esbuild.renderer.config.js

3. Project structure now:
![image](https://user-images.githubusercontent.com/13672022/119476016-dce9cd80-bd77-11eb-9853-45f0fdbddb5c.png)

**Expected**
Able to resolve `http://localhost:9080/worker.js`

**Actual Behaviour**
Blocked due these headers being set in HTML load:
```
res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
```

![image](https://user-images.githubusercontent.com/13672022/119476185-06a2f480-bd78-11eb-9d5d-49d5a31b0364.png)
![image](https://user-images.githubusercontent.com/13672022/119476196-086cb800-bd78-11eb-9b89-994b9b44f341.png)
![image](https://user-images.githubusercontent.com/13672022/119476204-0a367b80-bd78-11eb-954c-4ac89ff1b7d6.png)
