### PR TITLE
allow override of default config for build

### DIFF
--- a/packages/electron-esbuild/src/config.ts
+++ b/packages/electron-esbuild/src/config.ts
@@ -130,21 +130,21 @@ export class Worker<M = PossibleConfiguration, R = PossibleConfiguration> {
       )
     }
 
-    let mainConfigFinal: M = deepMerge(userMainConfig, this._main, {
+    let mainConfigFinal: M = deepMerge(this._main, userMainConfig, {
       clone: false,
     })
     let rendererConfigFinal: R | null =
       rendererConfig !== null && userRendererConfig !== null
-        ? deepMerge(userRendererConfig, this._renderer, { clone: false })
+        ? deepMerge(this._renderer, userRendererConfig, { clone: false })
         : null
 
     mainConfigFinal = deepMerge(
-      mainConfigFinal,
       this.configurator.main.toBuilderConfig(
         this._main,
         mainConfigFinal,
         Target.main,
       ) as Partial<M>,
+      mainConfigFinal,
       { clone: false },
     )
 
@@ -152,12 +152,12 @@ export class Worker<M = PossibleConfiguration, R = PossibleConfiguration> {
       rendererConfigFinal !== null
         ? this.configurator.renderer
           ? deepMerge(
-              rendererConfigFinal,
               this.configurator.renderer.toBuilderConfig(
                 this._renderer,
                 rendererConfigFinal,
                 Target.renderer,
               ) as Partial<R>,
+              rendererConfigFinal,
               { clone: false },
             )
           : null


### PR DESCRIPTION
This PR allows developer config settings to override the default config settings.

I ran into a situation where the packaged app throws an error when the esbuild step was performed with minify (default), but where the app runs without error if the esbuild step is performed without minification. This change allowed me to turn minification on/off within my esbuild.main.config.js  config file. 

Submitting PR since this capability might be useful to others.
