### PR TITLE
Allow users to utilize server.port value in vite.config.[ts/js] files.

### DIFF
--- a/packages/create-app/templates/react-vite-ts/src/renderer/vite.config.ts
+++ b/packages/create-app/templates/react-vite-ts/src/renderer/vite.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
   build: {
     target: 'chrome100', // electron version target
   },
+  server: {
+    port: 9080,
+  },
 })

--- a/packages/create-app/templates/react-vite/src/renderer/vite.config.js
+++ b/packages/create-app/templates/react-vite/src/renderer/vite.config.js
@@ -7,4 +7,7 @@ export default defineConfig({
   build: {
     target: 'chrome100', // electron version target
   },
+  server: {
+    port: 9080,
+  },
 })

--- a/packages/electron-esbuild/CHANGELOG.md
+++ b/packages/electron-esbuild/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Breaking Changes
+
+- Fixed bug where users could not set their own port in vite.config.[ts/js].
+  - 🚨 **Existing projects** will no longer use port `9080` by default. [Please modify the `server.port` property in your Vite config](https://vitejs.dev/config/#server-port) to your port of choice, or update your project to accomodate the Vite default port `3000`.
+  - New projects will set port `9080` as part of the initialization template.
+
 ## 5.0.2
 
 ### Changes

--- a/packages/electron-esbuild/src/builder/vite.builder.mts
+++ b/packages/electron-esbuild/src/builder/vite.builder.mts
@@ -100,12 +100,7 @@ export class ViteBuilder extends BaseBuilder<InlineConfig> {
     if (this._config.isRenderer) {
       _logger.log('Start vite dev server')
 
-      const server = await this._viteCreateServer({
-        ...this._inlineConfig,
-        server: {
-          port: 9080,
-        },
-      })
+      const server = await this._viteCreateServer(this._inlineConfig)
 
       await server.listen()
 


### PR DESCRIPTION
# Problem

Hard-coded port value prevents user from using configured Vite port in `vite.config.[ts/js]` files.

# Reproduction

1. Create new project via `npm init @electron-esbuild/app`.
2. Specify any Vite project template.
3. In your Vite frontend, add the following `server` property to `vite.config.ts` or `vite.config.js` file:
```ts
server: {
  port: 9089 // Something different from the hard-coded 9080 value. 
}
```
4. Run the project.
5. Observe port `9080` is still the preferred port.

# Notes on Changes

* Removal of the hard-coded default.
  * This a breaking change to existing users who assume the `9080` port value. This value should have been included as part of the initial templates, so I went ahead and added them. Feel free to reach out if you have any questions or concerns about this. 

* Please test locally before considering a merge. While I can confirm the fix on my end, I always suggest measuring twice before cutting.