### PR TITLE
Loosen up vite peer dependency to 4.x

### DIFF
--- a/packages/electron-esbuild/package.json
+++ b/packages/electron-esbuild/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "esbuild": "0.16.x",
-    "vite": "4.0.x"
+    "vite": "4.x"
   },
   "peerDependenciesMeta": {
     "vite": {


### PR DESCRIPTION
This will allow installing Vite 4.1 and up.